### PR TITLE
Just ignore when TDConnection.setCatalog is called

### DIFF
--- a/src/main/java/com/treasuredata/jdbc/TDConnection.java
+++ b/src/main/java/com/treasuredata/jdbc/TDConnection.java
@@ -363,7 +363,7 @@ public class TDConnection
     public void setCatalog(String catalog)
             throws SQLException
     {
-        throw new SQLException("Unsupported TDConnection#setCatalog(String)");
+        // "If the driver does not support catalogs, it will silently ignore this request."
     }
 
     public void setClientInfo(Properties properties)


### PR DESCRIPTION
> If the driver does not support catalogs, it will silently ignore this request.

https://docs.oracle.com/javase/8/docs/api/java/sql/Connection.html#setCatalog-java.lang.String-