### PR TITLE
Add a new mode to use API key even if username and password are set

### DIFF
--- a/src/main/java/com/treasuredata/jdbc/ApiConfig.java
+++ b/src/main/java/com/treasuredata/jdbc/ApiConfig.java
@@ -48,7 +48,6 @@ public class ApiConfig
         prop.setProperty(Config.TD_JDBC_USESSL, Boolean.toString(useSSL));
         prop.setProperty(Config.TD_API_SERVER_HOST, endpoint);
         prop.setProperty(Config.TD_API_SERVER_PORT, Integer.toString(port));
-
         if(apiKey.isDefined()) {
             prop.setProperty(Config.TD_API_KEY, apiKey.get());
         }
@@ -73,6 +72,7 @@ public class ApiConfig
             this.endpoint = config.endpoint;
             this.port = Option.of(config.port);
             this.useSSL = config.useSSL;
+            this.apiKey = config.apiKey;
             this.proxy = config.proxy;
         }
 

--- a/src/main/java/com/treasuredata/jdbc/Config.java
+++ b/src/main/java/com/treasuredata/jdbc/Config.java
@@ -30,6 +30,7 @@ public class Config
         implements Constants
 {
     public static final String TD_JDBC_USESSL = "usessl";
+    public static final String TD_JDBC_USEAPIKEY = "useapikey";
     public static final String TD_JDBC_USER = "user";
     public static final String TD_JDBC_PASSWORD = "password";
     public static final String TD_JDBC_APIKEY = "apikey";
@@ -46,6 +47,7 @@ public class Config
     public final String user;
     public final String password;
     public final Job.Type type;
+    public final boolean useApiKey;
     public final ApiConfig apiConfig;
     public final int resultRetryCountThreshold;
     public final long resultRetryWaitTimeMs;
@@ -56,6 +58,7 @@ public class Config
             String user,
             String password,
             Job.Type type,
+            boolean useApiKey,
             ApiConfig apiConfig,
             int resultRetryCountThreshold,
             long resultRetryWaitTimeMs
@@ -70,6 +73,7 @@ public class Config
             throw new SQLException("invalid job type within URL: " + type);
         }
         this.type = type;
+        this.useApiKey = useApiKey;
         this.apiConfig = apiConfig;
         this.resultRetryCountThreshold = resultRetryCountThreshold;
         this.resultRetryWaitTimeMs = resultRetryWaitTimeMs;
@@ -182,6 +186,9 @@ public class Config
                 }
                 else if (k.equals(TD_JDBC_JOB_TYPE)) {
                     config.setType(Job.toType(v));
+                }
+                else if (k.equals(TD_JDBC_USEAPIKEY)) {
+                    config.setUseApiKey(Boolean.parseBoolean(kv[1].toLowerCase()));
                 }
                 else if (k.equals(TD_JDBC_USESSL)) {
                     apiConfig.setUseSSL(Boolean.parseBoolean(kv[1].toLowerCase()));
@@ -341,7 +348,9 @@ public class Config
 
         // If both user and password are specified, use this pair instead of TD_API_KEY
         if(!isEmptyString(user) && !isEmptyString(password)) {
-            apiConfig.unsetApiKey();
+            if (!useApiKey) {
+                apiConfig.unsetApiKey();
+            }
         }
 
         // retry settings

--- a/src/main/java/com/treasuredata/jdbc/ConfigBuilder.java
+++ b/src/main/java/com/treasuredata/jdbc/ConfigBuilder.java
@@ -29,6 +29,7 @@ public class ConfigBuilder
     private String user;
     private String password;
     private Job.Type type = Job.Type.PRESTO; // Use presto by default
+    private boolean useApiKey;
     private ApiConfig apiConfig;
     private int resultRetryCountThreshold = Config.TD_JDBC_RESULT_RETRYCOUNT_THRESHOLD_DEFAULTVALUE;
     private long resultRetryWaitTimeMs = Config.TD_JDBC_RESULT_RETRY_WAITTIME_DEFAULTVALUE;
@@ -40,6 +41,7 @@ public class ConfigBuilder
         this.database = config.database;
         this.user = config.user;
         this.password = config.password;
+        this.useApiKey = config.useApiKey;
         this.type = config.type;
         this.apiConfig = config.apiConfig;
         this.resultRetryCountThreshold = config.resultRetryCountThreshold;
@@ -80,6 +82,10 @@ public class ConfigBuilder
         return this;
     }
 
+    public void setUseApiKey(boolean useApiKey) {
+        this.useApiKey = useApiKey;
+    }
+
     public ConfigBuilder setApiConfig(ApiConfig apiConfig) {
         this.apiConfig = apiConfig;
         return this;
@@ -102,6 +108,7 @@ public class ConfigBuilder
                 user,
                 password,
                 type,
+                useApiKey,
                 apiConfig != null ? apiConfig : new ApiConfig.ApiConfigBuilder().createApiConfig(),
                 resultRetryCountThreshold,
                 resultRetryWaitTimeMs


### PR DESCRIPTION
When I tested td-jdbc using API key on a SaaS application, JDBC configuration dialog on the SaaS required to set both `username` and `password` as mandatory fields. And with current implementation of td-jdbc https://github.com/treasure-data/td-jdbc/blob/14bd34eed8e96ee0a5c87de5568ba4ba43de9802/src/main/java/com/treasuredata/jdbc/Config.java#L344, `apikey` is unset when both `username` and `password` are passed and specifying a API key doesn't work in the case.

I think there are 2 options.

a. Change current behaviour of td-jdbc to leave `apikey` as is even if both `username` and `password`
b. Add a new param `useapikey` to prefer API key to username

I think a) is a simpler, but it could affect existing users. In this PR, I implemented b) just in case. If a) is better, I'll create another PR.